### PR TITLE
Einhdoven mappings

### DIFF
--- a/defaults/Eindhoven.json
+++ b/defaults/Eindhoven.json
@@ -1,0 +1,7 @@
+{
+  "authority": "http://standaarden.overheid.nl/owms/terms/Eindhoven_(gemeente)",
+  "publisher": "http://standaarden.overheid.nl/owms/terms/Eindhoven_(gemeente)",
+  "sourceCatalog": "https://data.eindhoven.nl",
+  "contact_point_name": "Gemeente Eindhoven",
+  "contact_point_website": "https://data.eindhoven.nl/pages/contact/"
+}

--- a/value-mappings/Eindhoven__Dataset__AccessRights.json
+++ b/value-mappings/Eindhoven__Dataset__AccessRights.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "public",
+    "target_value": "http://publications.europa.eu/resource/authority/access-right/PUBLIC"
+  },
+  {
+    "name": "restricted public",
+    "target_value": "http://publications.europa.eu/resource/authority/access-right/RESTRICED"
+  },
+  {
+    "name": "non-public",
+    "target_value": "http://publications.europa.eu/resource/authority/access-right/NON_PUBLIC"
+  }
+]

--- a/value-mappings/Eindhoven__Dataset__Frequency.json
+++ b/value-mappings/Eindhoven__Dataset__Frequency.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "irregular",
+    "target_value": "http://publications.europa.eu/resource/authority/frequency/IRREG"
+  }
+]

--- a/value-mappings/Eindhoven__Dataset__Language.json
+++ b/value-mappings/Eindhoven__Dataset__Language.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "nl",
+    "target_value": "http://publications.europa.eu/resource/authority/language/NLD"
+  }
+]

--- a/value-mappings/Eindhoven__Dataset__License.json
+++ b/value-mappings/Eindhoven__Dataset__License.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Publiek domein",
+    "target_value": "http://creativecommons.org/publicdomain/mark/1.0/deed.nl"
+  },
+  {
+    "name": "Public Domain",
+    "target_value": "http://creativecommons.org/publicdomain/mark/1.0/deed.nl"
+  },
+  {
+    "name": "CC BY",
+    "target_value": "http://creativecommons.org/licenses/by/4.0/deed.nl"
+  }
+]

--- a/value-mappings/Eindhoven__Dataset__MetadataLanguage.json
+++ b/value-mappings/Eindhoven__Dataset__MetadataLanguage.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "nl",
+    "target_value": "http://publications.europa.eu/resource/authority/language/NLD"
+  }
+]

--- a/value-mappings/Eindhoven__Dataset__Theme.json
+++ b/value-mappings/Eindhoven__Dataset__Theme.json
@@ -1,0 +1,54 @@
+[
+  {
+    "name": "Ruimte en infrastructuur",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Ruimte_en_infrastructuur"
+  },
+  {
+    "name": "Bestuur",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Bestuur"
+  },
+  {
+    "name": "Economie",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Economie"
+  },
+  {
+    "name": "Onderwijs en wetenschap",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Onderwijs_en_wetenschap"
+  },
+  {
+    "name": "Openbare orde en veiligheid",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Openbare_orde_en_veiligheid"
+  },
+  {
+    "name": "Verkeer",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Verkeer_(thema)"
+  },
+  {
+    "name": "Natuur en milieu",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Natuur_en_milieu"
+  },
+  {
+    "name": "Zorg en gezondheid",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Zorg_en_gezondheid"
+  },
+  {
+    "name": "Financiën",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Financien"
+  },
+  {
+    "name": "Recht",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Bestuursrecht"
+  },
+  {
+    "name": "Cultuur en recreatie",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Cultuur_en_recreatie"
+  },
+  {
+    "name": "Sociale zekerheid",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Sociale_zekerheid"
+  },
+  {
+    "name": "Huisvesting",
+    "target_value": "http://standaarden.overheid.nl/owms/terms/Huisvesting_(thema)"
+  }
+]

--- a/value-mappings/Eindhoven__Distribution__Format.json
+++ b/value-mappings/Eindhoven__Distribution__Format.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "json",
+    "target_value": "http://publications.europa.eu/resource/authority/file-type/JSON"
+  },
+  {
+    "name": "csv",
+    "target_value": "http://publications.europa.eu/resource/authority/file-type/CSV"
+  },
+  {
+    "name": "geojson",
+    "target_value": "http://publications.europa.eu/resource/authority/file-type/JSON"
+  },
+  {
+    "name": "shp",
+    "target_value": "http://publications.europa.eu/resource/authority/file-type/SHP"
+  }
+]

--- a/value-mappings/Eindhoven__Distribution__Language.json
+++ b/value-mappings/Eindhoven__Distribution__Language.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "nl",
+    "target_value": "http://publications.europa.eu/resource/authority/language/NLD"
+  }
+]

--- a/value-mappings/Eindhoven__Distribution__License.json
+++ b/value-mappings/Eindhoven__Distribution__License.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Publiek domein",
+    "target_value": "http://creativecommons.org/publicdomain/mark/1.0/deed.nl"
+  },
+  {
+    "name": "Public Domain",
+    "target_value": "http://creativecommons.org/publicdomain/mark/1.0/deed.nl"
+  },
+  {
+    "name": "CC BY",
+    "target_value": "http://creativecommons.org/licenses/by/4.0/deed.nl"
+  }
+]

--- a/value-mappings/Eindhoven__Distribution__MediaType.json
+++ b/value-mappings/Eindhoven__Distribution__MediaType.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "application/json",
+    "target_value": "https://www.iana.org/assignments/media-types/application/json"
+  },
+  {
+    "name": "text/csv",
+    "target_value": "https://www.iana.org/assignments/media-types/text/csv"
+  },
+  {
+    "name": "application/zip",
+    "target_value": "https://www.iana.org/assignments/media-types/application/zip"
+  }
+]

--- a/value-mappings/Eindhoven__Distribution__MetadataLanguage.json
+++ b/value-mappings/Eindhoven__Distribution__MetadataLanguage.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "nl",
+    "target_value": "http://publications.europa.eu/resource/authority/language/NLD"
+  }
+]


### PR DESCRIPTION
Introduces the mappings used for the Eindhoven catalog import.

- Sensible defaults
- Mapping string literals to URI's
- No blacklist or whitelist applies to the Eindhoven catalog import

\* Some mappings may be subject to change.